### PR TITLE
Add compile button. Disable Run button until AS compiler is ready

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -553,16 +553,6 @@ export class App extends React.Component<AppProps, AppState> {
     if (this.props.embeddingParams.type !== EmbeddingType.Arc) {
       toolbarButtons.push(
         <Button
-          key="Compile"
-          icon={<GoGear />}
-          label="Compile"
-          title="Compile Project: CtrlCmd + B"
-          isDisabled={this.toolbarButtonsAreDisabled() || !this.state.projectReady}
-          onClick={() => {
-            build();
-          }}
-        />,
-        <Button
           key="Run"
           icon={<Play />}
           label="Run"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -157,6 +157,11 @@ export interface AppState {
   quickStart: boolean;
   accountId: string;
   keyStore: KeyStore;
+
+  /**
+   * Project is ready and can be run or tested.
+   */
+  projectReady: boolean;
 }
 
 export interface AppProps {
@@ -228,8 +233,8 @@ export class App extends React.Component<AppProps, AppState> {
       isContentModified: false,
       quickStart: props.quickStart,
       accountId: App.getAccountId(),
-      keyStore: new BrowserLocalStorageKeystore()
-
+      keyStore: new BrowserLocalStorageKeystore(),
+      projectReady: false,
     };
     // TODO: Ugly hack used in File.save
     // TODO: There should be better way to propagate state.
@@ -299,7 +304,9 @@ export class App extends React.Component<AppProps, AppState> {
       this.setState({ project: appStore.getProject() });
       // Run delayed to avoid recursive dispatch (e.g. when logLn is called downstream)
       setTimeout(() => {
-        runTask("project:load", true, RunTaskExternals.Setup);
+        runTask("project:load", true, RunTaskExternals.Setup).then(() => {
+          this.setState({ projectReady: true });
+        })
       });
     });
     appStore.onDirtyFileUsed.register((file: File) => {
@@ -529,6 +536,7 @@ export class App extends React.Component<AppProps, AppState> {
             this.download();
           }}
         />,
+        /*
         <Button
           key="Share"
           icon={<GoRocket />}
@@ -538,28 +546,38 @@ export class App extends React.Component<AppProps, AppState> {
           onClick={() => {
             this.share();
           }}
-        />);
+        />
+        */
+      );
     }
     if (this.props.embeddingParams.type !== EmbeddingType.Arc) {
       toolbarButtons.push(
+        <Button
+          key="Compile"
+          icon={<GoGear />}
+          label="Compile"
+          title="Compile Project: CtrlCmd + B"
+          isDisabled={this.toolbarButtonsAreDisabled() || !this.state.projectReady}
+          onClick={() => {
+            build();
+          }}
+        />,
         <Button
           key="Run"
           icon={<Play />}
           label="Run"
           title="Run Project: CtrlCmd + Enter"
-          isDisabled={this.toolbarButtonsAreDisabled()}
+          isDisabled={this.toolbarButtonsAreDisabled() || !this.state.projectReady}
           onClick={() => {
             deployAndRun(this.state.fiddle);
           }}
         />,
-      );
-      toolbarButtons.push(
         <Button
           key="Test"
           icon={<GoCheck />}
           label="Test"
           title="Run project tests"
-          isDisabled={this.toolbarButtonsAreDisabled()}
+          isDisabled={this.toolbarButtonsAreDisabled() || !this.state.projectReady}
           onClick={() => {
             const contractSuffix = "_t" + new Date().getTime();
             deployAndRun(this.state.fiddle, "test.html", contractSuffix);

--- a/src/models/File.ts
+++ b/src/models/File.ts
@@ -228,6 +228,7 @@ export class File {
     } else {
       await Service.saveFile(this, app.state.fiddle);
     }
+    await app.build();
   }
   toString() {
     return "File [" + this.name + "]";

--- a/src/models/File.ts
+++ b/src/models/File.ts
@@ -228,7 +228,6 @@ export class File {
     } else {
       await Service.saveFile(this, app.state.fiddle);
     }
-    await app.build();
   }
   toString() {
     return "File [" + this.name + "]";


### PR DESCRIPTION
Fixes #88 
Fixes #96 (at least addresses it)
- Remove `Share` button
- Add `Compile` button
- Enable "Compile/Run/Test" only after `project:load` task is completed.
<img width="692" alt="Screen Shot 2019-03-26 at 1 19 32 PM" src="https://user-images.githubusercontent.com/470453/55030642-0ce78b80-4fca-11e9-964b-90217c8cb815.png">
