### PR TITLE
Revert "Add compile button. Disable Run button until AS compiler is ready"

### DIFF
--- a/src/actions/AppActions.ts
+++ b/src/actions/AppActions.ts
@@ -370,10 +370,7 @@ export async function deployAndRun(fiddleName: string, pageName: string = "", co
   const config = await getConfig();
   // NOTE: Page opened beforehand to avoid popup blocking
   // TODO: Show something better than empty window, e.g. stream compiler output?
-  let page: Window = null;
-  let timeout = setTimeout(() => {
-    page = window.open(`${config.pages}/${fiddleName}/loader.html`, "pageDevWindow");
-  }, 900);
+  const page = window.open(`${config.pages}/${fiddleName}/loader.html`, "pageDevWindow");
   try {
     await saveAll();
     clearLog();
@@ -383,24 +380,12 @@ export async function deployAndRun(fiddleName: string, pageName: string = "", co
       await deploy(contractName);
       const queryString = contractSuffix ?
         `?contractName=${contractName}` : "";
-      clearTimeout(timeout);
-      const newUrl = `${config.pages}/${fiddleName}/${pageName}${queryString}`;
-      if (page) {
-        page.location.replace(newUrl);
-      } else {
-        window.open(newUrl, "pageDevWindow");
-      }
+      page.location.replace(`${config.pages}/${fiddleName}/${pageName}${queryString}`);
     } else {
-      clearTimeout(timeout);
-      if (page) {
-        page.close();
-      }
-    }
-  } catch (e) {
-    clearTimeout(timeout);
-    if (page) {
       page.close();
     }
+  } catch (e) {
+    page.close();
     reportError(e);
   }
   popStatus();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -157,11 +157,6 @@ export interface AppState {
   quickStart: boolean;
   accountId: string;
   keyStore: KeyStore;
-
-  /**
-   * Project is ready and can be run or tested.
-   */
-  projectReady: boolean;
 }
 
 export interface AppProps {
@@ -233,8 +228,8 @@ export class App extends React.Component<AppProps, AppState> {
       isContentModified: false,
       quickStart: props.quickStart,
       accountId: App.getAccountId(),
-      keyStore: new BrowserLocalStorageKeystore(),
-      projectReady: false,
+      keyStore: new BrowserLocalStorageKeystore()
+
     };
     // TODO: Ugly hack used in File.save
     // TODO: There should be better way to propagate state.
@@ -304,9 +299,7 @@ export class App extends React.Component<AppProps, AppState> {
       this.setState({ project: appStore.getProject() });
       // Run delayed to avoid recursive dispatch (e.g. when logLn is called downstream)
       setTimeout(() => {
-        runTask("project:load", true, RunTaskExternals.Setup).then(() => {
-          this.setState({ projectReady: true });
-        })
+        runTask("project:load", true, RunTaskExternals.Setup);
       });
     });
     appStore.onDirtyFileUsed.register((file: File) => {
@@ -536,7 +529,6 @@ export class App extends React.Component<AppProps, AppState> {
             this.download();
           }}
         />,
-        /*
         <Button
           key="Share"
           icon={<GoRocket />}
@@ -546,9 +538,7 @@ export class App extends React.Component<AppProps, AppState> {
           onClick={() => {
             this.share();
           }}
-        />
-        */
-      );
+        />);
     }
     if (this.props.embeddingParams.type !== EmbeddingType.Arc) {
       toolbarButtons.push(
@@ -557,17 +547,19 @@ export class App extends React.Component<AppProps, AppState> {
           icon={<Play />}
           label="Run"
           title="Run Project: CtrlCmd + Enter"
-          isDisabled={this.toolbarButtonsAreDisabled() || !this.state.projectReady}
+          isDisabled={this.toolbarButtonsAreDisabled()}
           onClick={() => {
             deployAndRun(this.state.fiddle);
           }}
         />,
+      );
+      toolbarButtons.push(
         <Button
           key="Test"
           icon={<GoCheck />}
           label="Test"
           title="Run project tests"
-          isDisabled={this.toolbarButtonsAreDisabled() || !this.state.projectReady}
+          isDisabled={this.toolbarButtonsAreDisabled()}
           onClick={() => {
             const contractSuffix = "_t" + new Date().getTime();
             deployAndRun(this.state.fiddle, "test.html", contractSuffix);


### PR DESCRIPTION
Reverts nearprotocol/NEARStudio#110

It broke tests and also blocks popup on some browsers. I'll need to test it better with @ilblackdragon chrome.  