### PR TITLE
Fix false negative with fiddle ownership check

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -418,6 +418,7 @@ export class App extends React.Component<AppProps, AppState> {
       history.pushState({}, fiddle, `${prefix}f=${fiddle}`);
     }
     this.setState({ fiddle });
+    appStore.getProject().getModel().fiddleEditable = true;
     if (this.props.embeddingParams.type === EmbeddingType.Arc) {
       notifyArcAboutFork(fiddle);
     }
@@ -430,7 +431,6 @@ export class App extends React.Component<AppProps, AppState> {
       }
 
       await this.fork();
-      appStore.getProject().getModel().fiddleEditable = true;
     }
     return true;
   }


### PR DESCRIPTION
Fork confirmation prompt has appeared erroneously after new fiddle creation / manual fork of non-editable fiddle