### PR TITLE
{WIP} Updating templates to use the new contract API - Blocked

### DIFF
--- a/templates/01-hello-username/src/main.js
+++ b/templates/01-hello-username/src/main.js
@@ -10,18 +10,18 @@ async function initContract() {
   window.walletAccount = new nearlib.WalletAccount(window.near);
 
   // Getting the Account ID. If unauthorized yet, it's just empty string.
-  window.accountId = window.walletAccount.getAccountId();
-
-  // Initializing our contract APIs by contract name and configuration.
-  window.contract = await near.loadContract(nearConfig.contractName, {
+  if (window.walletAccount.getAccountId()) {
+    //Creating account object
+    account = await near.account(await window.walletAccount.getAccountId());
+    // Initializing our contract APIs by contract name and configuration.
+    window.contract = new nearlib.Contract(account, nearConfig.contractName, {
     // NOTE: This configuration only needed while NEAR is still in development
     // View methods are read only. They don't modify the state, but usually return some value.
     viewMethods: ["whoSaidHi"],
     // Change methods can modify the state. But you don't receive the returned value when called.
     changeMethods: ["sayHi"],
-    // Sender is the account ID to initialize transactions.
-    sender: window.accountId,
-  });
+    });
+  }
 }
 
 // Using initialized contract
@@ -41,7 +41,7 @@ async function doWork() {
 function signedOutFlow() {
   // Displaying the signed out flow container.
   document.getElementById('signed-out-flow').classList.remove('d-none');
-  // Adding an event to a sing-in button.
+  // Adding an event to a sign-in button.
   document.getElementById('sign-in-button').addEventListener('click', () => {
     window.walletAccount.requestSignIn(
       // The contract name that would be authorized to be called by the user's account.
@@ -60,7 +60,7 @@ function signedInFlow() {
   document.getElementById('signed-in-flow').classList.remove('d-none');
 
   // Displaying current account name.
-  document.getElementById('account-id').innerText = window.accountId;
+  document.getElementById('account-id').innerText = window.walletAccount.getAccountId();
 
   // Adding an event to a say-hi button.
   document.getElementById('say-hi').addEventListener('click', () => {
@@ -68,7 +68,7 @@ function signedInFlow() {
     window.contract.sayHi().then(updateWhoSaidHi);
   });
 
-  // Adding an event to a sing-out button.
+  // Adding an event to a sign-out button.
   document.getElementById('sign-out-button').addEventListener('click', () => {
     walletAccount.signOut();
     // Forcing redirect.

--- a/templates/02-counter/src/main.js
+++ b/templates/02-counter/src/main.js
@@ -3,15 +3,23 @@ async function connect() {
   // Initializing connection to the NEAR node.
   window.near = await nearlib.connect(Object.assign(nearConfig, { deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() }}));
 
-  // Needed to access wallet login
+  // Initializing Wallet based Account. It can work with NEAR DevNet wallet that
+  // is hosted at https://wallet.nearprotocol.com
   window.walletAccount = new nearlib.WalletAccount(window.near);
 
-  // Initializing our contract APIs by contract name and configuration.
-  window.contract = await near.loadContract(nearConfig.contractName, {
+  // Getting the Account ID. If unauthorized yet, it's just empty string.
+  if (window.walletAccount.getAccountId()) {
+    //Creating account object
+    account = await near.account(await window.walletAccount.getAccountId());
+    // Initializing our contract APIs by contract name and configuration.
+    window.contract = new nearlib.Contract(account, nearConfig.contractName, {
+    // NOTE: This configuration only needed while NEAR is still in development
+    // View methods are read only. They don't modify the state, but usually return some value.
     viewMethods: ["getCounter"],
+    // Change methods can modify the state. But you don't receive the returned value when called.
     changeMethods: ["incrementCounter", "decrementCounter"],
-    sender: window.walletAccount.getAccountId()
-  });
+    });
+  }
 }
 
 function updateUI() {

--- a/templates/04-guest-book/src/main.js
+++ b/templates/04-guest-book/src/main.js
@@ -122,16 +122,18 @@ async function init() {
   window.walletAccount = new nearlib.WalletAccount(window.near);
 
   // Getting the Account ID. If unauthorized yet, it's just empty string.
-  accountId = walletAccount.getAccountId();
-
-  // Initializing the contract.
-  // For now we need to specify method names from the contract manually.
-  // It also takes the Account ID which it would use for signing transactions.
-  contract = await near.loadContract(nearConfig.contractName, {
+  if (window.walletAccount.getAccountId()) {
+    //Creating account object
+    account = await near.account(await window.walletAccount.getAccountId());
+    // Initializing our contract APIs by contract name and configuration.
+    window.contract = new nearlib.Contract(account, nearConfig.contractName, {
+    // NOTE: This configuration only needed while NEAR is still in development
+    // View methods are read only. They don't modify the state, but usually return some value.
     viewMethods: ["getMessages"],
+    // Change methods can modify the state. But you don't receive the returned value when called.
     changeMethods: ["addMessage"],
-    sender: accountId,
-  });
+    });
+  }
 
   // Enable wallet link now that config is available
   $('a.wallet').removeClass('disabled').attr('href', nearConfig.walletUrl);

--- a/templates/05-token-contract/src/main.js
+++ b/templates/05-token-contract/src/main.js
@@ -3,15 +3,23 @@ async function connect() {
   // Initializing connection to the NEAR node.
   window.near = await nearlib.connect(Object.assign(nearConfig, { deps: { keyStore: new nearlib.keyStores.BrowserLocalStorageKeyStore() }}));
 
-  // Needed to access wallet login
+  // Initializing Wallet based Account. It can work with NEAR DevNet wallet that
+  // is hosted at https://wallet.nearprotocol.com
   window.walletAccount = new nearlib.WalletAccount(window.near);
 
-  // Initializing our contract APIs by contract name and configuration.
-  window.contract = await near.loadContract(nearConfig.contractName, {
+  // Getting the Account ID. If unauthorized yet, it's just empty string.
+  if (window.walletAccount.getAccountId()) {
+    //Creating account object
+    account = await near.account(await window.walletAccount.getAccountId());
+    // Initializing our contract APIs by contract name and configuration.
+    window.contract = new nearlib.Contract(account, nearConfig.contractName, {
+    // NOTE: This configuration only needed while NEAR is still in development
+    // View methods are read only. They don't modify the state, but usually return some value.
     viewMethods: ["totalSupply", "balanceOf", "allowance"],
+    // Change methods can modify the state. But you don't receive the returned value when called.
     changeMethods: ["init", "transfer", "approve", "transferFrom"],
-    sender: window.walletAccount.getAccountId()
-  });
+    });
+  }
 }
 
 function updateUI() {


### PR DESCRIPTION
### Summary of Changes
Updating templates to reflect new contract API 

Blocked: Currently, contract will not be loaded if user has not logged in. 
[Nearlib issue 55](https://github.com/nearprotocol/nearlib/issues/55) addresses this: 


To Do: 
Update documentation once PR is merged
Update near shell template once PR is merged 
@potatodepaulo 