### PR TITLE
 Load compiler from URL provided search query 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ templates/*/assembly/json
 templates/*/assembly/bignum
 templates/*/assembly/near.ts
 templates/*/setup.js
+
+templates/*/src/test.html

--- a/templates/01-hello-username/package.json
+++ b/templates/01-hello-username/package.json
@@ -17,9 +17,7 @@
     "icon": "typescript-lang-file-icon"
   },
   "dependencies": {
-    "near-runtime-ts": "github:nearprotocol/near-runtime-ts",
-    "assemblyscript-json": "github:nearprotocol/assemblyscript-json",
-    "bignum": "github:MaxGraey/bignum.wasm"
+    "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
   },
   "devDependencies": {
     "gh-pages": "^2.1.1",

--- a/templates/01-hello-username/src/test.html
+++ b/templates/01-hello-username/src/test.html
@@ -9,7 +9,7 @@
 </head>
 <body style="background: #fff">
   <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/nearprotocol/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
   <script src="./config.js"></script>
   <script src="./test-setup.js"></script>
   <script src="./test.js"></script>

--- a/templates/02-counter/package.json
+++ b/templates/02-counter/package.json
@@ -12,8 +12,6 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "dependencies": {
-    "assemblyscript-json": "github:nearprotocol/assemblyscript-json",
-    "bignum": "github:MaxGraey/bignum.wasm",
     "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
   },
   "devDependencies": {

--- a/templates/02-counter/src/test.html
+++ b/templates/02-counter/src/test.html
@@ -9,7 +9,7 @@
 </head>
 <body style="background: #fff">
   <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/nearprotocol/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
   <script src="./config.js"></script>
   <script src="./test-setup.js"></script>
   <script src="./test.js"></script>

--- a/templates/04-guest-book/package.json
+++ b/templates/04-guest-book/package.json
@@ -12,8 +12,6 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "dependencies": {
-    "assemblyscript-json": "github:nearprotocol/assemblyscript-json",
-    "bignum": "github:MaxGraey/bignum.wasm",
     "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
   },
   "devDependencies": {

--- a/templates/04-guest-book/src/test.html
+++ b/templates/04-guest-book/src/test.html
@@ -9,7 +9,7 @@
 </head>
 <body style="background: #fff">
   <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/nearprotocol/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
   <script src="./config.js"></script>
   <script src="./test-setup.js"></script>
   <script src="./test.js"></script>

--- a/templates/05-token-contract/package.json
+++ b/templates/05-token-contract/package.json
@@ -12,8 +12,6 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "dependencies": {
-    "assemblyscript-json": "github:nearprotocol/assemblyscript-json",
-    "bignum": "github:MaxGraey/bignum.wasm",
     "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
   },
   "devDependencies": {

--- a/templates/05-token-contract/src/test.html
+++ b/templates/05-token-contract/src/test.html
@@ -9,7 +9,7 @@
 </head>
 <body style="background: #fff">
   <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/nearprotocol/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
   <script src="./config.js"></script>
   <script src="./test-setup.js"></script>
   <script src="./test.js"></script>

--- a/templates/setup.js
+++ b/templates/setup.js
@@ -1,11 +1,14 @@
 // This file is not required when running the project locally. Its purpose is to set up the
 // AssemblyScript compiler when a new project has been loaded in WebAssembly Studio.
 
+const CURRENT_URL = new URL(window.location.href);
+const ASC_COMMMIT = CURRENT_URL.searchParams.get("asc") || "f8c87361ad1ebc92b06aae4386e056ed2e368f0a";
+
 require.config({
   paths: {
     "binaryen": "https://cdn.jsdelivr.net/gh/AssemblyScript/binaryen.js@84.0.0-nightly.20190522/index",
-    "assemblyscript": "https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@f8c87361ad1ebc92b06aae4386e056ed2e368f0a/dist/assemblyscript",
-    "assemblyscript/dist/asc": "https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@f8c87361ad1ebc92b06aae4386e056ed2e368f0a/dist/asc"
+    "assemblyscript": `https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@${ASC_COMMMIT}/dist/assemblyscript`,
+    "assemblyscript/dist/asc": `https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@${ASC_COMMMIT}/dist/asc`
   }
 });
 

--- a/templates/test.html
+++ b/templates/test.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.3.0/jasmine.css">
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.3.0/jasmine.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.3.0/jasmine-html.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/3.3.0/boot.js"></script>
+</head>
+<body style="background: #fff">
+  <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/nearprotocol/nearlib@09127f91aace8b95f97e8c51d5d32c5c7ad555e2/dist/nearlib.js"></script>
+  <script src="./config.js"></script>
+  <script src="./test-setup.js"></script>
+  <script src="./test.js"></script>
+</body>
+</html>

--- a/update_templates.sh
+++ b/update_templates.sh
@@ -7,6 +7,7 @@ TEMPLATE_DIRS="$(ls -d templates/0*)"
 for template in $TEMPLATE_DIRS; do
   echo $template
   cp ./templates/setup.js $template/setup.js
+  cp ./templates/test.html $template/src/test.html
   (cd $template && (rm yarn.lock || true) && yarn install --prod --no-lockfile)
   rm -rf $template/node_modules.bk;
   mkdir $template/node_modules.bk


### PR DESCRIPTION
`?asc=COMMITHASH` in the URL is checked first when loading the compiler. Useful for switching between compiler versions.

Also copies test.html each time so that the URL for nearlib is updated, which previously was causing tests to fail.