### PR TITLE
Update to near-bindgen-as

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ templates/*/assembly/near.ts
 templates/*/setup.js
 
 templates/*/src/test.html
+
+templates/*/neardev/shared-test/

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "minimatch": "^3.0.4",
     "monaco-editor": "^0.14.3",
     "mousetrap": "^1.6.2",
+    "near-bindgen-as": "^1.1.1",
     "near-runtime-ts": "^0.5.1",
     "near-shell": "^0.17.2",
     "nearlib": "^0.19.1",

--- a/src/utils/taskRunner.ts
+++ b/src/utils/taskRunner.ts
@@ -23,7 +23,7 @@ import { Project, fileTypeForExtension, mimeTypeForFileType } from "../models";
 import { Gulpy } from "../gulpy";
 import { Service } from "../service";
 import { Arc } from "../arc";
-import nearGulpUtils from "near-shell/gulp-utils";
+import nearGulpUtils from "near-bindgen-as/compiler";
 
 export enum RunTaskExternals {
   Default,
@@ -178,7 +178,7 @@ export async function runTask(
   }, {
     // modules
     "gulp": gulp,
-    "near-shell/gulp-utils": nearGulpUtils,
+    "near-bindgen-as/compiler": nearGulpUtils,
     "@wasm/studio-utils": {
       Service,
       getProject,

--- a/templates/01-hello-username/assembly/main.ts
+++ b/templates/01-hello-username/assembly/main.ts
@@ -1,4 +1,4 @@
-//@nearfile out
+//@nearfile
 import { context, storage, logging } from "near-runtime-ts";
 // --- contract code goes below
 

--- a/templates/01-hello-username/assembly/main.ts
+++ b/templates/01-hello-username/assembly/main.ts
@@ -1,4 +1,4 @@
-//@nearfile
+//@nearfile out
 import { context, storage, logging } from "near-runtime-ts";
 // --- contract code goes below
 

--- a/templates/01-hello-username/gulpfile.js
+++ b/templates/01-hello-username/gulpfile.js
@@ -1,5 +1,5 @@
 const gulp = require('gulp');
-const nearUtils = require('near-shell/gulp-utils');
+const nearUtils = require('near-bindgen-as/compiler');
 
 gulp.task('build', callback => {
   nearUtils.compile('./assembly/main.ts', './out/main.wasm', callback);

--- a/templates/01-hello-username/package.json
+++ b/templates/01-hello-username/package.json
@@ -17,14 +17,16 @@
     "icon": "typescript-lang-file-icon"
   },
   "dependencies": {
-    "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
+    "near-bindgen-as": "^1.1.1",
+    "near-runtime-ts": "^0.5.1"
   },
   "devDependencies": {
+    "assemblyscript": "^0.8.1",
     "gh-pages": "^2.1.1",
     "gulp": "^4.0.2",
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
-    "near-shell": "github:nearprotocol/near-shell",
+    "near-shell": "^0.18.0",
     "serve": "^11.1.0"
   }
 }

--- a/templates/02-counter/gulpfile.js
+++ b/templates/02-counter/gulpfile.js
@@ -1,5 +1,5 @@
 const gulp = require('gulp');
-const nearUtils = require('near-shell/gulp-utils');
+const nearUtils = require('near-bindgen-as/compiler');
 
 gulp.task('build', callback => {
   nearUtils.compile('./assembly/main.ts', './out/main.wasm', callback);

--- a/templates/02-counter/package.json
+++ b/templates/02-counter/package.json
@@ -12,14 +12,16 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "dependencies": {
-    "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
+    "near-bindgen-as": "^1.1.1",
+    "near-runtime-ts": "^0.5.1"
   },
   "devDependencies": {
+    "assemblyscript": "^0.8.1",
     "gh-pages": "^2.1.1",
     "gulp": "^4.0.2",
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
-    "near-shell": "github:nearprotocol/near-shell",
+    "near-shell": "^0.18.0",
     "serve": "^11.1.0"
   },
   "wasmStudio": {

--- a/templates/04-guest-book/gulpfile.js
+++ b/templates/04-guest-book/gulpfile.js
@@ -1,5 +1,5 @@
 const gulp = require('gulp');
-const nearUtils = require('near-shell/gulp-utils');
+const nearUtils = require('near-bindgen-as/compiler');
 
 gulp.task('build', callback => {
   nearUtils.compile('./assembly/main.ts', './out/main.wasm', callback);

--- a/templates/04-guest-book/package.json
+++ b/templates/04-guest-book/package.json
@@ -12,14 +12,16 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "dependencies": {
-    "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
+    "near-bindgen-as": "^1.1.1",
+    "near-runtime-ts": "^0.5.1"
   },
   "devDependencies": {
+    "assemblyscript": "^0.8.1",
     "gh-pages": "^2.1.1",
     "gulp": "^4.0.2",
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
-    "near-shell": "github:nearprotocol/near-shell",
+    "near-shell": "^0.18.0",
     "serve": "^11.1.0"
   },
   "wasmStudio": {

--- a/templates/05-token-contract/gulpfile.js
+++ b/templates/05-token-contract/gulpfile.js
@@ -1,5 +1,5 @@
 const gulp = require('gulp');
-const nearUtils = require('near-shell/gulp-utils');
+const nearUtils = require('near-bindgen-as/compiler');
 
 gulp.task('build', callback => {
   nearUtils.compile('./assembly/main.ts', './out/main.wasm', callback);

--- a/templates/05-token-contract/package.json
+++ b/templates/05-token-contract/package.json
@@ -12,14 +12,16 @@
     "test": "npm run build && jest test --env=near-shell/test_environment"
   },
   "dependencies": {
-    "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
+    "near-bindgen-as": "^1.1.1",
+    "near-runtime-ts": "^0.5.1"
   },
   "devDependencies": {
+    "assemblyscript": "^0.8.1",
     "gh-pages": "^2.1.1",
     "gulp": "^4.0.2",
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
-    "near-shell": "github:nearprotocol/near-shell",
+    "near-shell": "^0.18.0",
     "serve": "^11.1.0"
   },
   "wasmStudio": {

--- a/templates/setup.js
+++ b/templates/setup.js
@@ -1,54 +1,73 @@
 // This file is not required when running the project locally. Its purpose is to set up the
 // AssemblyScript compiler when a new project has been loaded in WebAssembly Studio.
+const URL_ARGS = (new URL(window.location.href)).searchParams;
+const SOURCE_LOCATION = URL_ARGS.get('src_loc') || 'gh/nearprotocol';
+const ASC_VERSION = URL_ARGS.get('asc') || '5ed994006b226d8b83f63830661146aebb9921ba';
+const BINDGEN_AS_VERSION = URL_ARGS.get('near-bindgen-as') || '1.1.1';
 
-const CURRENT_URL = new URL(window.location.href);
-const ASC_COMMMIT = CURRENT_URL.searchParams.get('asc') || 'f8c87361ad1ebc92b06aae4386e056ed2e368f0a';
+// Fetch assemblyscript's package.json so that the binaryen version matches.
+fetch(`https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@${ASC_VERSION}/package.json`)
+  .then(res => {
+    if (!res.ok) new Error('HTTP error ' + res.status);
+    return res.json();
+  })
+  .then(json => {
+    const BINARYEN_VERSION = URL_ARGS.get('binaryen') 
+                            || (json.dependencies && json.dependencies['binaryen'])
+                            || '89.0.0-nightly.20191113';
+    require.config({
+      paths: {
+        'binaryen': `https://cdn.jsdelivr.net/gh/AssemblyScript/binaryen.js@${BINARYEN_VERSION}/index`,
+        'assemblyscript': `https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@${ASC_VERSION}/dist/assemblyscript`,
+        'assemblyscript/dist/asc': `https://cdn.jsdelivr.net/${SOURCE_LOCATION}/assemblyscript@${ASC_VERSION}/dist/asc`,
+        'assemblyscript/dist/asc.map.js': `https://cdn.jsdelivr.net/${SOURCE_LOCATION}/assemblyscript@${ASC_VERSION}/dist/asc.map`,
+        'NearBindgen': `https://cdn.jsdelivr.net/npm/near-bindgen-as@${BINDGEN_AS_VERSION}/index`
+      }
+    });
 
-require.config({
-  paths: {
-    'binaryen': 'https://cdn.jsdelivr.net/gh/AssemblyScript/binaryen.js@84.0.0-nightly.20190522/index',
-    'assemblyscript': `https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@${ASC_COMMMIT}/dist/assemblyscript`,
-    'near-assemblyscript/dist/asc': `https://cdn.jsdelivr.net/gh/nearprotocol/assemblyscript@${ASC_COMMMIT}/dist/asc`
-  }
-});
+    logLn('Loading AssemblyScript compiler ...');
+    window.logLn = logLn;
 
-logLn('Loading AssemblyScript compiler ...');
-window.logLn = logLn;
+    Object.assign(window.StudioFs, {
+      readFileSync(path) {
+        const file = getProject().getFile(path);
+        return file ? file.data : null;
+      },
+      writeFileSync(path, contents) {
+        path = path.replace(/^\.\//, '');
+        const type = fileTypeForExtension(path.substring(path.lastIndexOf('.') + 1));
+        getProject().newFile(path, type, true).setData(contents);
+      },
+      existsSync(path) {
+        return !!getProject().getFile(path);
+      },
+      listDirSync(path) {
+        let dir = getProject().getFile(path);
+        if (dir == null) {
+          return dir;
+        }
+        assert(dir.type === 'directory');
+        return dir.list();
+      },
+      mkdirSync(path) {
+        getProject().newDirectory(path);
+      }
+    });
 
-Object.assign(window.StudioFs, {
-  readFileSync(path) {
-    const file = getProject().getFile(path);
-    return file ? file.data : null;
-  },
-  writeFileSync(path, contents) {
-    path = path.replace(/^\.\//, '');
-    const type = fileTypeForExtension(path.substring(path.lastIndexOf('.') + 1));
-    getProject().newFile(path, type, true).setData(contents);
-  },
-  existsSync(path) {
-    return !!getProject().getFile(path);
-  },
-  listDirSync(path) {
-    let dir = getProject().getFile(path);
-    if (dir == null) {
-      return dir;
-    }
-    assert(dir.type === 'directory');
-    return dir.list();
-  },
-  mkdirSync(path) {
-    getProject().newDirectory(path);
-  }
-});
+    require(['NearBindgen'], nearBindgen => {
+      window['near-bindgen-as'] = nearBindgen;
+      Object.assign(window['near-bindgen-as'], nearBindgen);
+    
+      require(['assemblyscript/dist/asc'], asc => {
+        Object.assign(window.AssemblyScriptCompiler, asc);
 
-require(['near-assemblyscript/dist/asc'], asc => {
-  Object.assign(window.AssemblyScriptCompiler, asc);
+        if (!window.process) {
+          window.process = {};
+        }
 
-  if (!window.process) {
-    window.process = {};
-  }
-
-  monaco.languages.typescript.typescriptDefaults.addExtraLib(asc.definitionFiles.assembly);
-  logLn('AssemblyScript compiler is ready!');
-  setupCallback();
-});
+        monaco.languages.typescript.typescriptDefaults.addExtraLib(asc.definitionFiles.assembly);
+        logLn('AssemblyScript compiler is ready!');
+        setupCallback();
+      });
+    });
+  });

--- a/update_templates.sh
+++ b/update_templates.sh
@@ -17,6 +17,7 @@ for template in $TEMPLATE_DIRS; do
       echo $parent
       mkdir $template/node_modules.bk/$parent;
       cp -r ./$template/node_modules/$parent/assembly $template/node_modules.bk/$parent/
+      cp ./$template/node_modules/$parent/package.json $template/node_modules.bk/$parent/
       # TODO use list files to only copy files needed to compile
       # for file in $(./node_modules/.bin/asc --listFiles assembly/index.ts --baseDir ./$package 2>&1 > /dev/null | grep -v \~lib); do
       #   cp -p ./$template/node_modules/$parent/$file ./$template/node_modules.bk/$parent/$file

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,8 @@ module.exports = env => {
         "react": "React",
         "react-dom": "ReactDOM",
         "fs": "StudioFs",
-        "near-assemblyscript/bin/asc": "AssemblyScriptCompiler"
+        "assemblyscript/dist/asc": "AssemblyScriptCompiler",
+        "assemblyscript/cli/asc": "AssemblyScriptCompiler"
     },
     plugins: [
         new WebpackBar(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,6 +5192,11 @@ near-assemblyscript@^0.7.4:
     opencollective-postinstall "^2.0.0"
     source-map-support "^0.5.13"
 
+near-bindgen-as@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/near-bindgen-as/-/near-bindgen-as-1.1.1.tgz#408f2aee991251ccfcaf149a28e2194fa948dea6"
+  integrity sha512-2JJPX47X2Ni0M8LJoIuZgcq6HVWi7Ha9oLSf8937kcJ8orKxS0mzGl79nO/d5xZh3LC19QoKSngJlDrl+cx9Nw==
+
 near-runtime-ts@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/near-runtime-ts/-/near-runtime-ts-0.5.1.tgz#d749fd6b0eb4f8bfe1b6ada7549aab7396b4d84f"


### PR DESCRIPTION
Made the bindgen code external so that we can update it without rebuilding the compiler.

Currently still rely on our version of the compiler which adds a check to lookup transformers in the global scope.