### PR TITLE
Add dockerfile for gitpod rust contract build

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+USER gitpod
+RUN rustup target add wasm32-unknown-unknown
+USER root


### PR DESCRIPTION
Associated Issue: #235 


### Summary of Changes

* Add a dockerfile for used by gitpod to build rust smart contract

### Test Plan

Not testable now but after gitpod is installed. It should be able to build a rust smart contract.
Reference:
https://www.gitpod.io/docs/42_config_docker/
https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile