### PR TITLE
template 01 README improvements

### DIFF
--- a/templates/01-hello-username/README.md
+++ b/templates/01-hello-username/README.md
@@ -3,29 +3,24 @@
 ## Description
 
 This example demonstrates how to integrate your application with NEAR Wallet.
-The contract is quite simple. It can store the account_id of last sender and return it. It also shows how you can debug contracts using logs.
+
+The contract is quite simple. It stores the `account_id` of last sender and return it. It also shows how you can debug contracts using logs.
 
 
 ## To Run
 
-*In NEAR Studio (https://studio.nearprotocol.com)*
-
 1. Click the "Run" button on the top of the Studio window
-
-2. You will be redirected to the new window where you can interract with the app.
-3. You'd be asked to sign-up with NEAR wallet (https://wallet.nearprotocol.com). If you don't have an account yet, then the wallet asks you to create one. 
-4. Once you have an account, you would be asked to authorize the application and the contract.
-5. Once authorized, you would be redirected back to the application and it would have access to your account ID and be able to issue transactions on behalf of your account. The transactions can only go to the authorized contract and can't include any tokens with them.
+2. You will be redirected to the new window where you can interact with the app
+3. You'll be asked to sign up with NEAR wallet (https://wallet.nearprotocol.com) and create an account if you don't have one yet
+4. Once you have an account, you'll be asked to authorize the application
+5. Once authorized, you'll be redirected back to the application. It will have access to your account ID and will be able to issue transactions on behalf of your account. The transactions can only go to this application's contract, and can't include any tokens.
 6. "Say Hi!"
 
 
 ## To Test
 
-*In NEAR Studio (https://studio.nearprotocol.com)*
-
 1. Click the "Test" button on the top of the Studio window
-
-2. You will be redirected to the output for the JavaScript tests described in `src/test.js` to show that the contract is performing properly.
+2. You will be redirected to the output for the JavaScript tests described in `src/test.js` to show that the contract is performing properly
 
 ## To Explore
 


### PR DESCRIPTION
* Use backticks around code concept `account_id`
* Use consistent tense ("you will" instead of both "you will" and "you would").
* Use (more) consistent end-of-bullet-point punctuation (mostly this meant removing periods)
* Don't say "in NEAR Studio", as the expectation is that people will primarily interact with this via NEAR Studio. As a newbie to NEAR, I found this unnecessary disclaimer confusing. It made me think maybe I wasn't where I thought I was.