### PR TITLE
Template 01 UI cleanup

### DIFF
--- a/templates/01-hello-username/src/index.html
+++ b/templates/01-hello-username/src/index.html
@@ -2,34 +2,23 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="styles.css">
 </head>
-<body style="background: #fff; margin-top: 3em">
-  <div class="container">
-    <div class="jumbotron">
-      <h3><i id="who">???</i> was the last person to say "Hi!"</h3>
-      &nbsp;<button id="refresh-button" class="btn btn-info btn-sm">Click here to find out!</button>
-    </div>
-    <hr>
-    <div id="signed-out-flow" class="d-none">
-      <div class="row">
-        <button id="sign-in-button" class="btn btn-primary btn-lg">Sign-in with NEAR</button>
-      </div>
-    </div> 
-    <div id="signed-in-flow" class="d-none">
-      <div class="row">
-        <h3>Hi, <i id="account-id"></i>!</h3>
-      </div>
-      <div class="row">
-        <div class="col-sm-3">
-          <button id="say-hi" class="btn btn-success btn-lg btn-block ">Say "Hi!"</button>
-        </div>
-        <div class="col-sm-3">
-          <button id="sign-out-button" class="btn btn-danger btn-lg btn-block">Sign-out</button>
-        </div>
-      </div>
-    </div> 
-  </div>
+<body>
+  <h1><a id="who" target="_blank">Who</a> was the last person to say hi?</h1>
+  <button id="sign-in" class="signed-out" style="display: none">
+    Sign in with NEAR to find out!
+  </button>
+  <button id="say-hi" class="signed-in" style="display: none">
+    Say hi!
+  </button>
+  <footer>
+    <p class="signed-in" style="display: none">
+      Signed in as <a id="account-id" href="https://wallet.nearprotocol.com/profile" target="_blank"></a>
+      • <a href="#signout" id="sign-out">sign out</a>
+    </p>
+  </footer>
   <script src="https://cdn.jsdelivr.net/npm/nearlib@0.20.0/dist/nearlib.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
   <script src="./config.js"></script>

--- a/templates/01-hello-username/src/main.js
+++ b/templates/01-hello-username/src/main.js
@@ -26,9 +26,6 @@ async function initContract() {
 
 // Using initialized contract
 async function doWork() {
-  // Setting up refresh button
-  document.getElementById('refresh-button').addEventListener('click', updateWhoSaidHi);
-
   // Based on whether you've authorized, checking which flow we should go.
   if (!window.walletAccount.isSignedIn()) {
     signedOutFlow();
@@ -40,9 +37,9 @@ async function doWork() {
 // Function that initializes the signIn button using WalletAccount
 function signedOutFlow() {
   // Displaying the signed out flow container.
-  document.getElementById('signed-out-flow').classList.remove('d-none');
+  Array.from(document.querySelectorAll('.signed-out')).forEach(el => el.style.display = '');
   // Adding an event to a sing-in button.
-  document.getElementById('sign-in-button').addEventListener('click', () => {
+  document.getElementById('sign-in').addEventListener('click', () => {
     window.walletAccount.requestSignIn(
       // The contract name that would be authorized to be called by the user's account.
       window.nearConfig.contractName,
@@ -57,7 +54,7 @@ function signedOutFlow() {
 // Main function for the signed-in flow (already authorized by the wallet).
 function signedInFlow() {
   // Displaying the signed in flow container.
-  document.getElementById('signed-in-flow').classList.remove('d-none');
+  Array.from(document.querySelectorAll('.signed-in')).forEach(el => el.style.display = '');
 
   // Displaying current account name.
   document.getElementById('account-id').innerText = window.accountId;
@@ -69,11 +66,16 @@ function signedInFlow() {
   });
 
   // Adding an event to a sing-out button.
-  document.getElementById('sign-out-button').addEventListener('click', () => {
+  document.getElementById('sign-out').addEventListener('click', e => {
+    e.preventDefault();
     walletAccount.signOut();
     // Forcing redirect.
     window.location.replace(window.location.origin + window.location.pathname);
   });
+
+  // fetch who last said hi without requiring button click
+  // but wait a second so the question is legible
+  setTimeout(updateWhoSaidHi, 1000);
 }
 
 // Function to update who said hi
@@ -83,8 +85,17 @@ function updateWhoSaidHi() {
   // we can't await for `contract.whoSaidHi()`, instead we attaching a callback function
   // usin `.then()`.
   contract.whoSaidHi().then((who) => {
-    // If the result doesn't have a value we fallback to the text
-    document.getElementById('who').innerText = who || 'Nobody (but you can be the first)';
+    const el = document.getElementById('who');
+    el.innerText = who || 'No one';
+
+    // only link to profile if there's a profile to link to
+    if (who) {
+      el.href = 'https://explorer.nearprotocol.com/accounts/' + who;
+    }
+
+    // change the ? to a !
+    const parent = el.parentNode;
+    parent.innerHTML = parent.innerHTML.replace('?', '!');
   });
 }
 

--- a/templates/01-hello-username/src/styles.css
+++ b/templates/01-hello-username/src/styles.css
@@ -1,0 +1,69 @@
+* {
+  box-sizing: border-box;
+}
+
+html, body { height: 100% }
+
+html {
+  --bg: #fff;
+  --fg: #25282A;
+  --primary: #FF585D;
+  --secondary: #6AD1E3;
+  --tertiary: #0072CE;
+
+  background-color: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  font-size: calc(.85em + 1vw);
+  line-height: 1.3;
+  text-align: center;
+}
+@media (prefers-color-scheme: dark) {
+  html {
+    --bg: #25282A;
+    --fg: #fff;
+  }
+}
+
+body {
+  margin: 0 auto;
+  max-width: 40em;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+
+a[href] { color: var(--primary) }
+a[href]:hover,
+a[href]:focus { color: var(--secondary) }
+a[href]:active { color: var(--tertiary) }
+
+button {
+  background: transparent;
+  border-radius: 5px;
+  border: 0.25em solid var(--primary);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.5em 1em;
+  position: relative;
+  transition: top 50ms;
+}
+button:hover,
+button:focus {
+  border-color: var(--secondary);
+  top: -1px;
+}
+button:active {
+  background: var(--tertiary);
+  border-color: var(--tertiary);
+  top: 3px;
+}
+
+footer {
+  display: flex;
+  font-size: 0.7em;
+  justify-content: space-between;
+}


### PR DESCRIPTION
## Summary of Changes

- [x] remove bootstrap
- [x] instead of defaulting to `??? was the last person to say "hi!"`, make it say "Who was the last person to say hi?"
- [x] when user loads, replace "who" with their name and make it a link to their page in the explorer – this looks better than italics, and teaches newbies about the explorer
- [x] also when the user loads, replace the "?" with a "!"
- [x] make "signed in as" link to wallet.nearprotocol.com/profile, to educate about this in addition to the explorer
- [x] clean up UI and make it more modern and friendly, including support for dark mode

## Test Plan

- [x] Create new "Example of NEAR Wallet integration"
- [x] Run the app without modifications
- [x] Try all features – sign in, say hi, sign out, sign in as someone else, say hi again

## Screenshots

### signed out

<img width="540" alt="Screen Shot 2020-01-31 at 15 09 06" src="https://user-images.githubusercontent.com/221614/73571194-0d4b8100-443c-11ea-9fa2-d64c2f6fdc90.png">

---

### signed in, no one said hi yet

<img width="541" alt="Screen Shot 2020-01-31 at 15 09 30" src="https://user-images.githubusercontent.com/221614/73571195-0d4b8100-443c-11ea-8fa1-3e4f8cc0927f.png">

---

### signed in, someone else said hi previously

<img width="540" alt="Screen Shot 2020-01-31 at 15 11 30" src="https://user-images.githubusercontent.com/221614/73571197-0d4b8100-443c-11ea-8236-0af0fc5c5f37.png">

---

### it also supports dark mode

Turn on dark mode on macOS and the page looks like this:

<img width="534" alt="Screen Shot 2020-01-31 at 15 12 00" src="https://user-images.githubusercontent.com/221614/73571198-0de41780-443c-11ea-92c1-6ed9948b9f06.png">
