### PR TITLE
add deps assemblyscript-json and bignum so "near build" succeeds on examples

### DIFF
--- a/templates/01-hello-username/package.json
+++ b/templates/01-hello-username/package.json
@@ -27,6 +27,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.18.0",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "bignum": "github:MaxGraey/bignum.wasm",
+    "assemblyscript-json": "^0.3.0"
   }
 }

--- a/templates/02-counter/package.json
+++ b/templates/02-counter/package.json
@@ -22,7 +22,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.18.0",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "assemblyscript-json": "^0.3.0"
   },
   "wasmStudio": {
     "name": "Counter Smart Contract",

--- a/templates/04-guest-book/package.json
+++ b/templates/04-guest-book/package.json
@@ -22,7 +22,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.18.0",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "assemblyscript-json": "^0.3.0"
   },
   "wasmStudio": {
     "name": "NEAR Guest Book",

--- a/templates/05-token-contract/package.json
+++ b/templates/05-token-contract/package.json
@@ -22,7 +22,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.20.1",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "assemblyscript-json": "^0.3.0"
   },
   "wasmStudio": {
     "name": "Token Smart Contract",


### PR DESCRIPTION
Quick PR adding dependencies that were lost somewhere.

**Problem**:
As an end user I try to download the examples from NEAR Studio and build them locally. When I run `near build` in the project directory, scary errors befall me.

**Solution**:
Add dependencies that allow for proper building of all the examples.