### PR TITLE
add bignum, assemblyscript-json devdeps, remove --prod from yarn install

### DIFF
--- a/templates/01-hello-username/package.json
+++ b/templates/01-hello-username/package.json
@@ -27,6 +27,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.18.0",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "bignum": "github:MaxGraey/bignum.wasm",
+    "assemblyscript-json": "^0.3.0"
   }
 }

--- a/templates/02-counter/package.json
+++ b/templates/02-counter/package.json
@@ -22,7 +22,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.18.0",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "assemblyscript-json": "^0.3.0"
   },
   "wasmStudio": {
     "name": "Counter Smart Contract",

--- a/templates/04-guest-book/package.json
+++ b/templates/04-guest-book/package.json
@@ -22,7 +22,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.18.0",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "assemblyscript-json": "^0.3.0"
   },
   "wasmStudio": {
     "name": "NEAR Guest Book",

--- a/templates/05-token-contract/package.json
+++ b/templates/05-token-contract/package.json
@@ -22,7 +22,8 @@
     "jest": "^24.8.0",
     "jest-environment-node": "^24.8.0",
     "near-shell": "^0.20.1",
-    "serve": "^11.1.0"
+    "serve": "^11.1.0",
+    "assemblyscript-json": "^0.3.0"
   },
   "wasmStudio": {
     "name": "Token Smart Contract",

--- a/update_templates.sh
+++ b/update_templates.sh
@@ -8,7 +8,7 @@ for template in $TEMPLATE_DIRS; do
   echo $template
   cp ./templates/setup.js $template/setup.js
   cp ./templates/test.html $template/src/test.html
-  (cd $template && (rm yarn.lock || true) && yarn install --prod --no-lockfile)
+  (cd $template && (rm yarn.lock || true) && yarn install --no-lockfile)
   rm -rf $template/node_modules.bk;
   mkdir $template/node_modules.bk
   for package in $(ls -d $template/node_modules/*); do


### PR DESCRIPTION
I think I see what might be going on with NEAR Studio, and having to do with two dependencies and dependencies that don't get installed but are needed due to a `prod` flag cascading with `yarn install --prod`.

Let's please keep this open until I get a chance to reach out to some folks. This can be a good learning experience for us. Also, I'll be curious to see how the onrender site shows up.